### PR TITLE
fix(config): compile to es5

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,8 +3,8 @@ import './logging.aspect';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { Component } from "@angular/core";
-import { Wove } from "aspect.js";
-//import { Wove } from 'aspect.js-angular';
+// import { Wove } from "aspect.js";
+import { Wove } from 'aspect.js-angular';
 
 @Wove()
 @Component({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
     "sourceMap": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
Compile to es5 because es6 classes cannot be invoked as functions.
Use `aspect.js-angular` `@Wove`.